### PR TITLE
feat: simplify wallet connection by removing twitter auth requirement

### DIFF
--- a/metaplex-nft-project/reveal-website/index.html
+++ b/metaplex-nft-project/reveal-website/index.html
@@ -1494,53 +1494,14 @@
         let currentWallet = null;
         let currentPublicKey = null;
 
-        async function connectWallet() {
-            if (!firebase.auth().currentUser) {
-                showErrorMessage('Please connect with Twitter first');
-                return;
-            }
-            
-            try {
-                const wallet = await connectToWallet();
-                if (wallet && wallet.publicKey) {
-                    currentWallet = wallet;
-                    currentPublicKey = wallet.publicKey.toString();
-                    updateWalletUI();
-                    showSuccessMessage('Wallet connected successfully!');
-                } else {
-                    throw new Error('No wallet could be connected. Please install Phantom or Solflare.');
-                }
-            } catch (error) {
-                showErrorMessage('Wallet connection failed: ' + error.message);
-            }
-        }
+        function connectWallet() {
+            const walletChoice = confirm('Choose your wallet:\n\nClick "OK" for Phantom\nClick "Cancel" for Solflare');
 
-        async function connectToWallet() {
-            // Try Phantom first
-            if (window.solana && window.solana.isPhantom) {
-                try {
-                    const response = await window.solana.connect();
-                    if (response.publicKey) {
-                        return { wallet: 'Phantom', publicKey: response.publicKey };
-                    }
-                } catch (e) {
-                    console.log('Phantom connection failed:', e.message);
-                }
+            if (walletChoice) {
+                connectToPhantomWallet();
+            } else {
+                connectToSolflareWallet();
             }
-            
-            // Try Solflare
-            if (window.solflare) {
-                try {
-                    const response = await window.solflare.connect();
-                    if (response && response.publicKey) {
-                        return { wallet: 'Solflare', publicKey: response.publicKey };
-                    }
-                } catch (e) {
-                    console.log('Solflare connection failed:', e.message);
-                }
-            }
-            
-            return null;
         }
 
         function updateWalletUI() {


### PR DESCRIPTION
## Summary
- allow connecting Phantom or Solflare wallet directly without Twitter login
- prompt users to choose preferred wallet on connect

## Testing
- `npm test` (fails: Missing script "test")
- `cd metaplex-nft-project/reveal-website && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68962a0133548333b4a2f10af8092b92